### PR TITLE
Use userid key in transaction edits

### DIFF
--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -117,7 +117,7 @@ const HomePage = () => {
         await axios.post("/transactions/edit-transaction", {
           payload: {
             ...values,
-            userId: user._id,
+            userid: user._id,
           },
           transactionId: editable._id,
         });

--- a/controllers/chatbotCtrl.js
+++ b/controllers/chatbotCtrl.js
@@ -18,7 +18,7 @@ async function handleChatbot(req, res) {
   try {
     const { message, userid } = req.body || {};
     if (!message || !userid) {
-      return res.status(400).json({ error: "Message and userId are required" });
+      return res.status(400).json({ error: "Message and userid are required" });
     }
     if (!GEMINI_API_KEY) {
       return res.status(500).json({ error: "Server misconfigured: GEMINI_API_KEY is missing" });
@@ -38,7 +38,7 @@ async function handleAnalysis(req, res) {
   try {
     const { type, data, userid } = req.body || {};
     if (!type || !data || !userid) {
-      return res.status(400).json({ error: "Type, data, and userId are required" });
+      return res.status(400).json({ error: "Type, data, and userid are required" });
     }
     if (!GEMINI_API_KEY) {
       return res.status(500).json({ error: "Server misconfigured: GEMINI_API_KEY is missing" });


### PR DESCRIPTION
## Summary
- use `userid` when editing a transaction so it matches server expectations
- update chatbot controller messages to refer to `userid`

## Testing
- `CI=true npm test --prefix client -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `node -e "..."` (simulate editing transaction to verify `userid` field)


------
https://chatgpt.com/codex/tasks/task_b_68a805b742fc832fbf22b68a3ab6ebab