### PR TITLE
refactor: configure API base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Ignore environment variable files
 .env
+
+# Node dependencies
+node_modules/
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Pocketly is a powerful and intuitive expense tracker application built using the
     ```bash
     MONGODB_URI=<your_mongodb_connection_string>
     REACT_APP_GEMINI_API_KEY=<your_genai_api_key>
+    REACT_APP_API_BASE=http://localhost:5000/api/v1
     ```
 4. Install the frontend dependencies:
     ```bash

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://localhost:5000/api/v1

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -12,10 +12,12 @@ const Register = () => {
   // Serve from /public/assets
   const registerHero1 = "/assets/loginhero2.png";
 
+  const API_BASE = process.env.REACT_APP_API_BASE || "/api/v1";
+
   const submitHandler = async (values) => {
     try {
       setLoading(true);
-      await axios.post(`${process.env.REACT_APP_API_BASE}/users/register`, values);
+      await axios.post(`${API_BASE}/users/register`, values);
       message.success("Registration successful");
       navigate("/login");
     } catch (error) {


### PR DESCRIPTION
## Summary
- centralize API base URL with fallback in Register page
- document `REACT_APP_API_BASE` and provide sample `.env`
- ignore node modules in git

## Testing
- `npm test --prefix client -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_b_68a80d188980832f88f7d4d4867d98f5