### PR TITLE
Fix duplicate date range selector in HomePage

### DIFF
--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -165,12 +165,6 @@ const HomePage = () => {
             <Select.Option value="income">INCOME</Select.Option>
             <Select.Option value="expense">EXPENSE</Select.Option>
           </Select>
-          {frequency === "custom" && (
-            <RangePicker
-              value={selectedDate}
-              onChange={(values) => setSelectedDate(values)}
-            />
-          )}
         </div>
         <div className="switch-icons">
           <UnorderedListOutlined


### PR DESCRIPTION
## Summary
- remove second RangePicker in Select Type section so only frequency filter shows a date range selector

## Testing
- `CI=true npm test --prefix client`
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_b_68a80f5c3d5c832f83c2b8d0c8de91fc